### PR TITLE
Advanced File Output

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -2,6 +2,7 @@
 library logger;
 
 export 'src/outputs/file_output_stub.dart'
-    if (dart.library.io) 'src/outputs/file_output.dart'
+    if (dart.library.io) 'src/outputs/file_output.dart';
+export 'src/outputs/advanced_file_output_stub.dart'
     if (dart.library.io) 'src/outputs/advanced_file_output.dart';
 export 'web.dart';

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -2,5 +2,6 @@
 library logger;
 
 export 'src/outputs/file_output_stub.dart'
-    if (dart.library.io) 'src/outputs/file_output.dart';
+    if (dart.library.io) 'src/outputs/file_output.dart'
+    if (dart.library.io) 'src/outputs/advanced_file_output.dart';
 export 'web.dart';

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -6,6 +6,11 @@ import '../log_level.dart';
 import '../log_output.dart';
 import '../output_event.dart';
 
+extension _NumExt on num {
+  String get twoDigits => toString().padLeft(2, '0');
+  String get threeDigits => toString().padLeft(3, '0');
+}
+
 /// Writes the log output to a file.
 class AdvancedFileOutput extends LogOutput {
   AdvancedFileOutput({
@@ -98,7 +103,9 @@ class AdvancedFileOutput extends LogOutput {
       return;
     }
 
-    final newName = DateTime.now().toString();
+    final t = DateTime.now();
+    final newName =
+        '${t.year}-${t.month.twoDigits}-${t.day.twoDigits}_${t.hour.twoDigits}-${t.minute.twoDigits}-${t.second.twoDigits}-${t.millisecond.threeDigits}';
     if (_targetFile == null) {
       // just create a new file on first boot
       await _openFile(File('${directory!.path}/$newName-init.txt'));

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -91,7 +91,8 @@ class AdvancedFileOutput extends LogOutput {
   void _writeOutBuffer() {
     if (_sink == null) return; //wait until _sink becomes available
     for (final event in _buffer) {
-      _sink?.writeAll(event.lines, Platform.lineTerminator);
+      //
+      _sink?.writeAll(event.lines, Platform.isWindows ? '\r\n' : '\n');
       _sink?.writeln();
     }
     _buffer.clear();

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -115,6 +115,13 @@ class AdvancedFileOutput extends LogOutput {
 
   Future<void> _updateTargetFile() async {
     if (_targetFile == null) {
+      //if logger wasn't destroyed properly, there may be a latest.log file from the previous
+      //session. we do this check to detect it and rename it to avoid overwriting
+      final prev = File('$_path/${_genFileName(isLatest: true)}');
+      if (_rotatingFilesMode && await prev.exists()) {
+        await prev.rename('$_path/${_genFileName(isLatest: false)}.lost');
+      }
+
       // just create a new file on first boot
       await _openNewFile();
     } else {

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import '../log_level.dart';
+import '../log_output.dart';
+import '../output_event.dart';
+
+/// Writes the log output to a file.
+class AdvancedFileOutput extends LogOutput {
+  AdvancedFileOutput({
+    this.directory,
+    this.file,
+    this.overrideExisting = false,
+    this.encoding = utf8,
+    List<Level>? writeImmediately,
+    this.maxDelay = const Duration(seconds: 2),
+    this.maxBufferSize = 2000,
+    this.maxLogFileSizeMB = 1,
+  })  : writeImmediately = writeImmediately ??
+            [
+              Level.error,
+              Level.fatal,
+              Level.warning,
+              // ignore: deprecated_member_use_from_same_package
+              Level.wtf,
+            ],
+        assert(
+          (file != null ? 1 : 0) + (directory != null ? 1 : 0) == 1,
+          'Either file or directory must be set',
+        );
+
+  final File? file;
+  final Directory? directory;
+
+  final bool overrideExisting;
+  final Encoding encoding;
+
+  final List<Level> writeImmediately;
+  final Duration maxDelay;
+  final int maxLogFileSizeMB;
+  final int maxBufferSize;
+
+  IOSink? _sink;
+  File? _targetFile;
+  Timer? _bufferWriteTimer;
+  Timer? _targetFileUpdater;
+
+  final List<OutputEvent> _buffer = [];
+
+  bool get dynamicFilesMode => directory != null;
+  File? get targetFile => _targetFile;
+
+  @override
+  Future<void> init() async {
+    if (dynamicFilesMode) {
+      //we use sync directory check to avoid losing
+      //potential initial boot logs in early crash scenarios
+      if (!directory!.existsSync()) {
+        directory!.createSync(recursive: true);
+      }
+
+      _targetFileUpdater = Timer.periodic(
+        const Duration(minutes: 1),
+        (_) => _updateTargetFile(),
+      );
+    }
+
+    _bufferWriteTimer = Timer.periodic(maxDelay, (_) => _writeOutBuffer());
+    await _updateTargetFile(); //run first setup without waiting for timer tick
+  }
+
+  @override
+  void output(OutputEvent event) {
+    _buffer.add(event);
+    // If event level is present in writeImmediately, write out the buffer
+    // along with any other possible elements that accumulated in it since
+    // the last timer tick
+    // Also write out if buffer is overfilled
+    if (_buffer.length > maxBufferSize ||
+        writeImmediately.contains(event.level)) {
+      _writeOutBuffer();
+    }
+  }
+
+  void _writeOutBuffer() {
+    if (_sink == null) return; //wait until _sink becomes available
+    for (final event in _buffer) {
+      _sink?.writeAll(event.lines, Platform.lineTerminator);
+      _sink?.writeln();
+    }
+    _buffer.clear();
+  }
+
+  Future<void> _updateTargetFile() async {
+    if (!dynamicFilesMode) {
+      await _openFile(file!);
+      return;
+    }
+
+    final newName = DateTime.now().toString();
+    if (_targetFile == null) {
+      // just create a new file on first boot
+      await _openFile(File('${directory!.path}/$newName-init.txt'));
+    } else {
+      final proposed = File('${directory!.path}/$newName-next.txt');
+      try {
+        if (await _targetFile!.length() > maxLogFileSizeMB * 1000000) {
+          await _closeCurrentFile();
+          await _openFile(proposed);
+        }
+      } catch (e) {
+        // try creating another file and working with it
+        await _closeCurrentFile();
+        await _openFile(proposed);
+      }
+    }
+  }
+
+  Future<void> _openFile(File proposed) async {
+    _targetFile = proposed;
+    _sink = _targetFile?.openWrite(
+      mode: overrideExisting ? FileMode.writeOnly : FileMode.writeOnlyAppend,
+      encoding: encoding,
+    );
+  }
+
+  Future<void> _closeCurrentFile() async {
+    await _sink?.flush();
+    await _sink?.close();
+    _sink = null; //explicitly make null until assigned again
+  }
+
+  @override
+  Future<void> destroy() async {
+    _bufferWriteTimer?.cancel();
+    _targetFileUpdater?.cancel();
+    await _closeCurrentFile();
+  }
+}

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -75,7 +75,7 @@ class AdvancedFileOutput extends LogOutput {
             ],
         _file = maxFileSizeKB > 0 ? File('$path/$latestFileName') : File(path);
 
-  /// Logs directory path by default, particular log file path if [_maxFileSizeKB] is 0
+  /// Logs directory path by default, particular log file path if [_maxFileSizeKB] is 0.
   final String _path;
 
   final bool _overrideExisting;
@@ -110,8 +110,8 @@ class AdvancedFileOutput extends LogOutput {
   Future<void> init() async {
     if (_rotatingFilesMode) {
       final dir = Directory(_path);
-      //we use sync directory check to avoid losing
-      //potential initial boot logs in early crash scenarios
+      // We use sync directory check to avoid losing potential initial boot logs
+      // in early crash scenarios.
       if (!dir.existsSync()) {
         dir.createSync(recursive: true);
       }
@@ -124,16 +124,15 @@ class AdvancedFileOutput extends LogOutput {
 
     _bufferWriteTimer = Timer.periodic(_maxDelay, (_) => _writeOutBuffer());
     await _openSink();
-    await _updateTargetFile(); //run first check without waiting for timer tick
+    await _updateTargetFile(); // Run first check without waiting for timer tick
   }
 
   @override
   void output(OutputEvent event) {
     _buffer.add(event);
     // If event level is present in writeImmediately, write out the buffer
-    // along with any other possible elements that accumulated in it since
-    // the last timer tick
-    // Also write out if buffer is overfilled
+    // along with any other possible elements that accumulated since
+    // the last timer tick. Additionally, if the buffer is full.
     if (_buffer.length > _maxBufferSize ||
         _writeImmediately.contains(event.level)) {
       _writeOutBuffer();
@@ -141,7 +140,7 @@ class AdvancedFileOutput extends LogOutput {
   }
 
   void _writeOutBuffer() {
-    if (_sink == null) return; //wait until _sink becomes available
+    if (_sink == null) return; // Wait until _sink becomes available
     for (final event in _buffer) {
       _sink?.writeAll(event.lines, Platform.isWindows ? '\r\n' : '\n');
       _sink?.writeln();
@@ -153,7 +152,7 @@ class AdvancedFileOutput extends LogOutput {
     try {
       if (await _file.exists() &&
           await _file.length() > _maxFileSizeKB * 1024) {
-        // rotate the log file
+        // Rotate the log file
         await _closeSink();
         await _file.rename('$_path/${_fileNameFormatter(DateTime.now())}');
         await _openSink();
@@ -161,7 +160,7 @@ class AdvancedFileOutput extends LogOutput {
     } catch (e, s) {
       print(e);
       print(s);
-      // try creating another file and working with it
+      // Try creating another file and working with it
       await _closeSink();
       await _openSink();
     }
@@ -177,7 +176,7 @@ class AdvancedFileOutput extends LogOutput {
   Future<void> _closeSink() async {
     await _sink?.flush();
     await _sink?.close();
-    _sink = null; //explicitly make null until assigned again
+    _sink = null; // Explicitly set null until assigned again
   }
 
   @override

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -108,9 +108,9 @@ class AdvancedFileOutput extends LogOutput {
         '${t.year}-${t.month.twoDigits}-${t.day.twoDigits}_${t.hour.twoDigits}-${t.minute.twoDigits}-${t.second.twoDigits}-${t.millisecond.threeDigits}';
     if (_targetFile == null) {
       // just create a new file on first boot
-      await _openFile(File('${directory!.path}/$newName-init.txt'));
+      await _openFile(File('${directory!.path}/${newName}_init.txt'));
     } else {
-      final proposed = File('${directory!.path}/$newName-next.txt');
+      final proposed = File('${directory!.path}/${newName}_next.txt');
       try {
         if (await _targetFile!.length() > maxLogFileSizeMB * 1000000) {
           await _closeCurrentFile();

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -124,7 +124,9 @@ class AdvancedFileOutput extends LogOutput {
 
     _bufferFlushTimer = Timer.periodic(_maxDelay, (_) => _flushBuffer());
     await _openSink();
-    await _updateTargetFile(); // Run first check without waiting for timer tick
+    if (_rotatingFilesMode) {
+      await _updateTargetFile(); // Run first check without waiting for timer tick
+    }
   }
 
   @override

--- a/lib/src/outputs/advanced_file_output_stub.dart
+++ b/lib/src/outputs/advanced_file_output_stub.dart
@@ -25,8 +25,8 @@ class AdvancedFileOutput extends LogOutput {
     Duration maxDelay = const Duration(seconds: 2),
     int maxBufferSize = 2000,
     int maxLogFileSizeMB = 1,
-    String Function(DateTime timestamp, {required bool isLatest})?
-        fileNameFormatter,
+    String initialFileName = 'latest.log',
+    String Function(DateTime timestamp)? fileNameFormatter,
   }) {
     throw UnsupportedError("Not supported on this platform.");
   }

--- a/lib/src/outputs/advanced_file_output_stub.dart
+++ b/lib/src/outputs/advanced_file_output_stub.dart
@@ -5,11 +5,20 @@ import '../log_level.dart';
 import '../log_output.dart';
 import '../output_event.dart';
 
-/// Writes the log output to a file.
+/// AdvancedFileOutput allows accumulating logs in a temporary buffer for
+/// a short period [maxDelay] of time before writing them out to a file,
+/// resuling in less frequent writes. [writeImmediately] list contains
+/// the log levels that are written out immediately ([Level.warning],
+/// [Level.error] and [Level.fatal] by default).
+///
+/// It also has a [rotatingFilesMode] (enabled by default) that allows
+/// automatically creating new log files on each [AdvancedFileOutput] init
+/// or when the [maxLogFileSizeMB] is reached. Set [maxLogFileSizeMB] to 0
+/// to disable this behaviour and treat [path] as a particular file path
+/// rather than a directory for auto-created logs.
 class AdvancedFileOutput extends LogOutput {
   AdvancedFileOutput({
-    Directory? directory,
-    File? file,
+    required String path,
     bool overrideExisting = false,
     Encoding encoding = utf8,
     List<Level>? writeImmediately,
@@ -20,7 +29,8 @@ class AdvancedFileOutput extends LogOutput {
     throw UnsupportedError("Not supported on this platform.");
   }
 
-  File? get targetFile => null;
+  File? get targetFile =>
+      throw UnsupportedError("Not supported on this platform.");
 
   @override
   void output(OutputEvent event) {

--- a/lib/src/outputs/advanced_file_output_stub.dart
+++ b/lib/src/outputs/advanced_file_output_stub.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../log_level.dart';
+import '../log_output.dart';
+import '../output_event.dart';
+
+/// Writes the log output to a file.
+class AdvancedFileOutput extends LogOutput {
+  AdvancedFileOutput({
+    Directory? directory,
+    File? file,
+    bool overrideExisting = false,
+    Encoding encoding = utf8,
+    List<Level>? writeImmediately,
+    Duration maxDelay = const Duration(seconds: 2),
+    int maxBufferSize = 2000,
+    int maxLogFileSizeMB = 1,
+  }) {
+    throw UnsupportedError("Not supported on this platform.");
+  }
+
+  File? get targetFile => null;
+
+  @override
+  void output(OutputEvent event) {
+    throw UnsupportedError("Not supported on this platform.");
+  }
+}

--- a/lib/src/outputs/advanced_file_output_stub.dart
+++ b/lib/src/outputs/advanced_file_output_stub.dart
@@ -25,11 +25,13 @@ class AdvancedFileOutput extends LogOutput {
     Duration maxDelay = const Duration(seconds: 2),
     int maxBufferSize = 2000,
     int maxLogFileSizeMB = 1,
+    String Function(DateTime timestamp, {required bool isLatest})?
+        fileNameFormatter,
   }) {
     throw UnsupportedError("Not supported on this platform.");
   }
 
-  File? get targetFile =>
+  File? get currentFile =>
       throw UnsupportedError("Not supported on this platform.");
 
   @override

--- a/lib/src/outputs/advanced_file_output_stub.dart
+++ b/lib/src/outputs/advanced_file_output_stub.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import '../log_level.dart';
 import '../log_output.dart';
@@ -51,14 +50,11 @@ class AdvancedFileOutput extends LogOutput {
     Duration maxDelay = const Duration(seconds: 2),
     int maxBufferSize = 2000,
     int maxFileSizeKB = 1024,
-    String initialFileName = 'latest.log',
+    String latestFileName = 'latest.log',
     String Function(DateTime timestamp)? fileNameFormatter,
   }) {
     throw UnsupportedError("Not supported on this platform.");
   }
-
-  File? get currentFile =>
-      throw UnsupportedError("Not supported on this platform.");
 
   @override
   void output(OutputEvent event) {

--- a/lib/src/outputs/advanced_file_output_stub.dart
+++ b/lib/src/outputs/advanced_file_output_stub.dart
@@ -5,18 +5,44 @@ import '../log_level.dart';
 import '../log_output.dart';
 import '../output_event.dart';
 
-/// AdvancedFileOutput allows accumulating logs in a temporary buffer for
-/// a short period [maxDelay] of time before writing them out to a file,
-/// resuling in less frequent writes. [writeImmediately] list contains
-/// the log levels that are written out immediately ([Level.warning],
-/// [Level.error] and [Level.fatal] by default).
+/// Accumulates logs in a buffer to reduce frequent disk, writes while optionally
+/// switching to a new log file if it reaches a certain size.
 ///
-/// It also has a [rotatingFilesMode] (enabled by default) that allows
-/// automatically creating new log files on each [AdvancedFileOutput] init
-/// or when the [maxLogFileSizeMB] is reached. Set [maxLogFileSizeMB] to 0
-/// to disable this behaviour and treat [path] as a particular file path
-/// rather than a directory for auto-created logs.
+/// [AdvancedFileOutput] offer various improvements over the original
+/// [FileOutput]:
+/// * Managing an internal buffer which collects the logs and only writes
+/// them after a certain period of time to the disk.
+/// * Dynamically switching log files instead of using a single one specified
+/// by the user, when the current file reaches a specified size limit (optionally).
+///
+/// The buffered output can significantly reduce the
+/// frequency of file writes, which can be beneficial for (micro-)SD storage
+/// and other types of low-cost storage (e.g. on IoT devices). Specific log
+/// levels can trigger an immediate flush, without waiting for the next timer
+/// tick.
+///
+/// New log files are created when the current file reaches the specified size
+/// limit. This is useful for writing "archives" of telemetry data and logs
+/// while keeping them structured.
 class AdvancedFileOutput extends LogOutput {
+  /// Creates a buffered file output.
+  ///
+  /// By default, the log is buffered until either the [maxBufferSize] has been
+  /// reached, the timer controlled by [maxDelay] has been triggered or an
+  /// [OutputEvent] contains a [writeImmediately] log level.
+  ///
+  /// [maxFileSizeKB] controls the log file rotation. The output automatically
+  /// switches to a new log file as soon as the current file exceeds it.
+  /// Use -1 to disable log rotation.
+  ///
+  /// [maxDelay] describes the maximum amount of time before the buffer has to be
+  /// written to the file.
+  ///
+  /// Any log levels that are specified in [writeImmediately] trigger an immediate
+  /// flush to the disk ([Level.warning], [Level.error] and [Level.fatal] by default).
+  ///
+  /// [path] is either treated as directory for rotating or as target file name,
+  /// depending on [maxFileSizeKB].
   AdvancedFileOutput({
     required String path,
     bool overrideExisting = false,
@@ -24,7 +50,7 @@ class AdvancedFileOutput extends LogOutput {
     List<Level>? writeImmediately,
     Duration maxDelay = const Duration(seconds: 2),
     int maxBufferSize = 2000,
-    int maxLogFileSizeMB = 1,
+    int maxFileSizeKB = 1024,
     String initialFileName = 'latest.log',
     String Function(DateTime timestamp)? fileNameFormatter,
   }) {

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -100,4 +100,24 @@ void main() {
       ),
     );
   });
+
+  test('Detect lost log files', () async {
+    var output = AdvancedFileOutput(path: dir.path);
+    await output.init();
+
+    final event0 = OutputEvent(LogEvent(Level.fatal, ""), ["Fatal"]);
+
+    output.output(event0);
+    //don't destroy old output here, simulate crash
+
+    var newOutput = AdvancedFileOutput(path: dir.path);
+    await newOutput.init();
+
+    final files = dir.listSync();
+    final paths = [for (final f in files) f.path];
+
+    await newOutput.destroy();
+
+    expect(paths, containsOnce((e) => (e as String).endsWith('.lost')));
+  });
 }

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:logger/logger.dart';
+import 'package:logger/src/outputs/advanced_file_output.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var file = File("${Directory.systemTemp.path}/dart_advanced_logger_test.log");
+  var dir = Directory("${Directory.systemTemp.path}/dart_advanced_logger_dir");
+  setUp(() async {
+    await file.create(recursive: true);
+    await dir.create(recursive: true);
+  });
+
+  tearDown(() async {
+    await file.delete();
+    await dir.delete(recursive: true);
+  });
+
+  test('Real file read and write with buffer accumulation', () async {
+    var output = AdvancedFileOutput(
+      file: file,
+      maxDelay: const Duration(milliseconds: 500),
+    );
+    await output.init();
+
+    final event0 = OutputEvent(LogEvent(Level.info, ""), ["First event"]);
+    final event1 = OutputEvent(LogEvent(Level.info, ""), ["Second event"]);
+    final event2 = OutputEvent(LogEvent(Level.info, ""), ["Third event"]);
+
+    output.output(event0);
+    output.output(event1);
+    output.output(event2);
+
+    //wait until buffer writes out to file
+    await Future.delayed(const Duration(seconds: 1));
+
+    await output.destroy();
+
+    var content = await file.readAsString();
+    expect(
+      content,
+      allOf(
+        contains("First event"),
+        contains("Second event"),
+        contains("Third event"),
+      ),
+    );
+  });
+
+  test('Real file read and write with dynamic file names and immediate output',
+      () async {
+    var output = AdvancedFileOutput(
+      directory: dir,
+      writeImmediately: [Level.info],
+    );
+    await output.init();
+
+    final event0 = OutputEvent(LogEvent(Level.info, ""), ["First event"]);
+    final event1 = OutputEvent(LogEvent(Level.info, ""), ["Second event"]);
+    final event2 = OutputEvent(LogEvent(Level.info, ""), ["Third event"]);
+
+    output.output(event0);
+    output.output(event1);
+    output.output(event2);
+
+    final targetFile = output.targetFile;
+
+    await output.destroy();
+
+    var content = await targetFile?.readAsString();
+    expect(
+      content,
+      allOf(
+        contains("First event"),
+        contains("Second event"),
+        contains("Third event"),
+      ),
+    );
+  });
+}

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -18,8 +18,9 @@ void main() {
 
   test('Real file read and write with buffer accumulation', () async {
     var output = AdvancedFileOutput(
-      file: file,
+      path: file.path,
       maxDelay: const Duration(milliseconds: 500),
+      maxLogFileSizeMB: 0,
     );
     await output.init();
 
@@ -50,7 +51,7 @@ void main() {
   test('Real file read and write with dynamic file names and immediate output',
       () async {
     var output = AdvancedFileOutput(
-      directory: dir,
+      path: dir.path,
       writeImmediately: [Level.info],
     );
     await output.init();

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -114,10 +114,11 @@ void main() {
     await newOutput.init();
 
     final files = dir.listSync();
-    final paths = [for (final f in files) f.path];
+    final lost = [for (final f in files) f.path]
+        .where((p) => p.endsWith('.lost'))
+        .toList();
 
     await newOutput.destroy();
-
-    expect(paths, containsOnce((e) => (e as String).endsWith('.lost')));
+    expect(lost, isNotEmpty);
   });
 }

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:logger/logger.dart';
-import 'package:logger/src/outputs/advanced_file_output.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -96,7 +96,7 @@ void main() {
 
     //And again for another roll
     await output.init();
-    final event2 = OutputEvent(LogEvent(Level.fatal, ""), ["2" * 1500]);
+    final event2 = OutputEvent(LogEvent(Level.fatal, ""), ["3" * 1500]);
     output.output(event2);
     await output.destroy();
 

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -20,7 +20,7 @@ void main() {
     var output = AdvancedFileOutput(
       path: file.path,
       maxDelay: const Duration(milliseconds: 500),
-      maxLogFileSizeMB: 0,
+      maxFileSizeKB: 0,
     );
     await output.init();
 

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -64,17 +64,39 @@ void main() {
     output.output(event1);
     output.output(event2);
 
-    final targetFile = output.targetFile;
-
     await output.destroy();
 
-    var content = await targetFile?.readAsString();
+    final logFile = dir.listSync().first as File;
+    var content = await logFile.readAsString();
     expect(
       content,
       allOf(
         contains("First event"),
         contains("Second event"),
         contains("Third event"),
+      ),
+    );
+  });
+
+  test('Flush temporary buffer on destroy', () async {
+    var output = AdvancedFileOutput(path: dir.path);
+    await output.init();
+
+    final event0 = OutputEvent(LogEvent(Level.info, ""), ["Last event"]);
+    final event1 = OutputEvent(LogEvent(Level.info, ""), ["Very last event"]);
+
+    output.output(event0);
+    output.output(event1);
+
+    await output.destroy();
+
+    final logFile = dir.listSync().first as File;
+    var content = await logFile.readAsString();
+    expect(
+      content,
+      allOf(
+        contains("Last event"),
+        contains("Very last event"),
       ),
     );
   });

--- a/test/outputs/advanced_file_output_test.dart
+++ b/test/outputs/advanced_file_output_test.dart
@@ -32,7 +32,7 @@ void main() {
     output.output(event1);
     output.output(event2);
 
-    //wait until buffer writes out to file
+    // Wait until buffer is flushed to file
     await Future.delayed(const Duration(seconds: 1));
 
     await output.destroy();
@@ -88,13 +88,13 @@ void main() {
     output.output(event0);
     await output.destroy();
 
-    //Start again to roll files on init without waiting for timer tick
+    // Start again to roll files on init without waiting for timer tick
     await output.init();
     final event1 = OutputEvent(LogEvent(Level.fatal, ""), ["2" * 1500]);
     output.output(event1);
     await output.destroy();
 
-    //And again for another roll
+    // And again for another roll
     await output.init();
     final event2 = OutputEvent(LogEvent(Level.fatal, ""), ["3" * 1500]);
     output.output(event2);


### PR DESCRIPTION
This type of file output is mainly targeted for low-cost IoT platforms (like RPi). It optimises some of the aspects of the original File Output, specifically:
- It has an internal temporary buffer which accumulates the logs and prints them out after a certain period. This reduces the frequency of file writes which is good for microSD storages and other types of cheap storages on IoT devices. It is possible to specify the levels of messages which are printed out immediately, without waiting for the next timer tick. By default these are warnings, errors and fatals.
- It has a simple manager for dynamically creating log files instead of using a single one specified by the user. The log files are created in two scenarios: on logger init and when the current log file reaches a size limit. The file names consists of a date+time followed by either "-init" or "-next" suffix depending on the reason why the file was created. This is useful for writing "archives" of telemetry data and logs while keeping them structured.