### PR TITLE
Tag field

### DIFF
--- a/lib/src/log_event.dart
+++ b/lib/src/log_event.dart
@@ -5,6 +5,7 @@ class LogEvent {
   final dynamic message;
   final Object? error;
   final StackTrace? stackTrace;
+  final String? tag;
 
   /// Time when this log was created.
   final DateTime time;
@@ -15,5 +16,6 @@ class LogEvent {
     DateTime? time,
     this.error,
     this.stackTrace,
+    this.tag,
   }) : time = time ?? DateTime.now();
 }

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -36,6 +36,7 @@ class Logger {
   final LogFilter _filter;
   final LogPrinter _printer;
   final LogOutput _output;
+  final String? _tag;
   bool _active = true;
 
   /// Create a new instance of Logger.
@@ -48,9 +49,11 @@ class Logger {
     LogPrinter? printer,
     LogOutput? output,
     Level? level,
+    String? tag,
   })  : _filter = filter ?? defaultFilter(),
         _printer = printer ?? defaultPrinter(),
-        _output = output ?? defaultOutput() {
+        _output = output ?? defaultOutput(),
+        _tag = tag {
     var filterInit = _filter.init();
     if (level != null) {
       _filter.level = level;
@@ -75,8 +78,9 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    t(message, time: time, error: error, stackTrace: stackTrace);
+    t(message, time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.trace].
@@ -85,8 +89,10 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    log(Level.trace, message, time: time, error: error, stackTrace: stackTrace);
+    log(Level.trace, message,
+        time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.debug].
@@ -95,8 +101,10 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    log(Level.debug, message, time: time, error: error, stackTrace: stackTrace);
+    log(Level.debug, message,
+        time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.info].
@@ -105,8 +113,10 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    log(Level.info, message, time: time, error: error, stackTrace: stackTrace);
+    log(Level.info, message,
+        time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.warning].
@@ -115,9 +125,10 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
     log(Level.warning, message,
-        time: time, error: error, stackTrace: stackTrace);
+        time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.error].
@@ -126,8 +137,10 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    log(Level.error, message, time: time, error: error, stackTrace: stackTrace);
+    log(Level.error, message,
+        time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.wtf].
@@ -138,8 +151,9 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    f(message, time: time, error: error, stackTrace: stackTrace);
+    f(message, time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message at level [Level.fatal].
@@ -148,8 +162,10 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
-    log(Level.fatal, message, time: time, error: error, stackTrace: stackTrace);
+    log(Level.fatal, message,
+        time: time, error: error, stackTrace: stackTrace, tag: tag);
   }
 
   /// Log a message with [level].
@@ -159,6 +175,7 @@ class Logger {
     DateTime? time,
     Object? error,
     StackTrace? stackTrace,
+    String? tag,
   }) {
     if (!_active) {
       throw ArgumentError('Logger has already been closed.');
@@ -177,6 +194,8 @@ class Logger {
       time: time,
       error: error,
       stackTrace: stackTrace,
+      // individual log tag has higher priority than Logger tag
+      tag: tag ?? _tag,
     );
     for (var callback in _logCallbacks) {
       callback(logEvent);

--- a/lib/src/printers/logfmt_printer.dart
+++ b/lib/src/printers/logfmt_printer.dart
@@ -33,6 +33,9 @@ class LogfmtPrinter extends LogPrinter {
     if (event.error != null) {
       output.write(' error="${event.error}"');
     }
+    if (event.tag != null) {
+      output.write(' tag="${event.tag}"');
+    }
 
     return [output.toString()];
   }

--- a/lib/src/printers/pretty_printer.dart
+++ b/lib/src/printers/pretty_printer.dart
@@ -399,6 +399,11 @@ class PrettyPrinter extends LogPrinter {
     var color = _getLevelColor(level);
     if (_includeBox[level]!) buffer.add(color(_topBorder));
 
+    if (tag != null) {
+      buffer.add(color('$verticalLineAtLevel$tag'));
+      if (_includeBox[level]!) buffer.add(color(_middleBorder));
+    }
+
     if (error != null) {
       for (var line in error.split('\n')) {
         buffer.add(color('$verticalLineAtLevel$line'));
@@ -415,11 +420,6 @@ class PrettyPrinter extends LogPrinter {
 
     if (time != null) {
       buffer.add(color('$verticalLineAtLevel$time'));
-      if (_includeBox[level]!) buffer.add(color(_middleBorder));
-    }
-
-    if (tag != null) {
-      buffer.add(color('$verticalLineAtLevel$tag'));
       if (_includeBox[level]!) buffer.add(color(_middleBorder));
     }
 

--- a/lib/src/printers/pretty_printer.dart
+++ b/lib/src/printers/pretty_printer.dart
@@ -251,6 +251,7 @@ class PrettyPrinter extends LogPrinter {
       timeStr,
       errorStr,
       stackTraceStr,
+      event.tag,
     );
   }
 
@@ -391,6 +392,7 @@ class PrettyPrinter extends LogPrinter {
     String? time,
     String? error,
     String? stacktrace,
+    String? tag,
   ) {
     List<String> buffer = [];
     var verticalLineAtLevel = (_includeBox[level]!) ? ('$verticalLine ') : '';
@@ -413,6 +415,11 @@ class PrettyPrinter extends LogPrinter {
 
     if (time != null) {
       buffer.add(color('$verticalLineAtLevel$time'));
+      if (_includeBox[level]!) buffer.add(color(_middleBorder));
+    }
+
+    if (tag != null) {
+      buffer.add(color('$verticalLineAtLevel$tag'));
       if (_includeBox[level]!) buffer.add(color(_middleBorder));
     }
 

--- a/lib/src/printers/simple_printer.dart
+++ b/lib/src/printers/simple_printer.dart
@@ -36,9 +36,10 @@ class SimplePrinter extends LogPrinter {
   @override
   List<String> log(LogEvent event) {
     var messageStr = _stringifyMessage(event.message);
+    var tagStr = event.tag != null ? '  [${event.tag}]' : '';
     var errorStr = event.error != null ? '  ERROR: ${event.error}' : '';
-    var timeStr = printTime ? 'TIME: ${event.time.toIso8601String()}' : '';
-    return ['${_labelFor(event.level)} $timeStr $messageStr$errorStr'];
+    var timeStr = printTime ? ' TIME: ${event.time.toIso8601String()}' : '';
+    return ['${_labelFor(event.level)}$tagStr $timeStr $messageStr$errorStr'];
   }
 
   String _labelFor(Level level) {

--- a/test/printers/pretty_printer_test.dart
+++ b/test/printers/pretty_printer_test.dart
@@ -24,6 +24,19 @@ void main() {
     expect(actualLogString, contains(expectedMessage));
   });
 
+  test('should print a tag', () {
+    final expectedMessage = 'some message with a tag';
+    final printer = PrettyPrinter();
+
+    final event = LogEvent(Level.debug, expectedMessage,
+        error: 'some error', stackTrace: StackTrace.current, tag: 'SomeTag');
+
+    final actualLog = printer.log(event);
+    final actualLogString = readMessage(actualLog);
+    expect(actualLogString, contains('SomeTag'));
+    expect(actualLogString, contains(expectedMessage));
+  });
+
   test('should print custom emoji or fallback', () {
     final expectedMessage = 'some message with an emoji';
     final emojiPrettyPrinter = PrettyPrinter(

--- a/test/printers/simple_printer_test.dart
+++ b/test/printers/simple_printer_test.dart
@@ -9,6 +9,7 @@ void main() {
     'some message',
     error: 'some error',
     stackTrace: StackTrace.current,
+    tag: 'SomeTag',
   );
 
   var plainPrinter = SimplePrinter(colors: false, printTime: false);
@@ -17,7 +18,7 @@ void main() {
     var outputs = plainPrinter.log(event);
 
     expect(outputs, hasLength(1));
-    expect(outputs[0], '[T]  some message  ERROR: some error');
+    expect(outputs[0], '[T]  [SomeTag]  some message  ERROR: some error');
   });
 
   group('color', () {
@@ -40,6 +41,12 @@ void main() {
     var printer = SimplePrinter(printTime: true);
 
     expect(printer.log(event)[0], contains('TIME'));
+  });
+
+  test('print tag', () {
+    var printer = SimplePrinter();
+
+    expect(printer.log(event)[0], contains('[SomeTag]'));
   });
 
   test('does not print time', () {


### PR DESCRIPTION
For big projects with many submodules, it is handy to mark the submodule that sent a log message. For example, if you have a realtime project with Teams, Users and Chats, and certain event parsing for some of these instances has failed, you'd probably want to print something like "[TEAMS] Failed fetching new avatar for team 2352379". That way, it's much easier to notice the desired messages. 
Basically I'm proposing to add a nullable "tag" field for Logger itself and individual log events (individual tags override Logger tag). This is not done on Printer level because Printer tags can't be individual for each log.
I'm not sure about 2 things:
1. How to format the tag in SimplePrinter: "[SomeTag]" or "TAG: SomeTag. I like the first variant because it's more compact.
2. Where to put it in PrettyPrinter. Right now it shows at the top of the message.