### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/SourceHorizon/logger
 
 topics:
 - cli
+- logging
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,9 @@ description: Small, easy to use and extensible logger which prints beautiful log
 version: 2.3.0
 repository: https://github.com/SourceHorizon/logger
 
+topics:
+- cli
+
 environment:
   sdk: ">=2.17.0 <4.0.0"
 


### PR DESCRIPTION
Topics helps users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to `pubspec.yaml` as follows:

```yaml
topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics