### PR TITLE
Fix rotation of log files.

### DIFF
--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -179,10 +179,10 @@ class AdvancedFileOutput extends LogOutput {
           await _file.length() > _maxFileSizeKB * 1024) {
         // Rotate the log file
         await _closeSink();
-        await _file.rename('$_path/${_fileNameFormatter(DateTime.now())}');
+        await _file.copy('$_path/${_fileNameFormatter(DateTime.now())}');
         await _deleteRotatedFiles();
-        // Reset file ref to "latest"
-        _file = maxFileSizeKB > 0 ? File('$path/$latestFileName') : File(path);
+        // Clear contents of "latest"
+        await _file.writeAsString("", mode: FileMode.write, flush: true);
         await _openSink();
       }
     } catch (e, s) {

--- a/lib/src/outputs/advanced_file_output.dart
+++ b/lib/src/outputs/advanced_file_output.dart
@@ -181,6 +181,8 @@ class AdvancedFileOutput extends LogOutput {
         await _closeSink();
         await _file.rename('$_path/${_fileNameFormatter(DateTime.now())}');
         await _deleteRotatedFiles();
+        // Reset file ref to "latest"
+        _file = maxFileSizeKB > 0 ? File('$path/$latestFileName') : File(path);
         await _openSink();
       }
     } catch (e, s) {


### PR DESCRIPTION
Using `AdvancedFileOutput` on Linux (Debian) I noticed that the rotation of log files did not work as expected.
`latest.log` did get renamed to whatever the configuration defined, but the logger would keep writing to this file.
This would lead to log files far exceeding the size defined with `maxFileSizeKB`.

This PR fixes this.
